### PR TITLE
Create build_env.yml

### DIFF
--- a/infrastructure/build_env.yml
+++ b/infrastructure/build_env.yml
@@ -1,0 +1,1 @@
+# This file will contain our build package dependencies (apt, manual installs etc.) This will be in Ansible YAML format so we can spin up new build servers as needed via a single command


### PR DESCRIPTION
This file is a place holder for Ansible build environment as CODE :) If we were to loose the Jenkins instance with the pre-defined build requirements for this component, what would be needed to create it again from scratch in a 100% automated way?
